### PR TITLE
Require at least ohai 4.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'kierranm@gmail.com'
 license 'apachev2'
 description 'Ohai plugin for getting EC2 Tags'
 long_description 'Ohai plugin for getting EC2 Tags'
-version '0.2.0'
+version '0.2.1'
 issues_url 'https://github.com/KierranM/ec2-tags-ohai-plugin/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/KierranM/ec2-tags-ohai-plugin' if respond_to?(:source_url)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,4 @@ supports 'fedora'
 supports 'amazon'
 supports 'windows'
 
-depends 'ohai'
+depends 'ohai', '>= 4.0.0'


### PR DESCRIPTION
The `ohai_plugin` resource didn't exist until version `4.0.0` of the `ohai` cookbook.