### PR TITLE
Rename `client` var to `ec2_client` to prevent scoping issues

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'kierranm@gmail.com'
 license 'apachev2'
 description 'Ohai plugin for getting EC2 Tags'
 long_description 'Ohai plugin for getting EC2 Tags'
-version '0.2.2'
+version '0.2.3'
 issues_url 'https://github.com/KierranM/ec2-tags-ohai-plugin/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/KierranM/ec2-tags-ohai-plugin' if respond_to?(:source_url)
 

--- a/templates/default/ec2-tags.rb
+++ b/templates/default/ec2-tags.rb
@@ -9,8 +9,8 @@ Ohai.plugin(:EC2Tags) do
     begin
       require 'aws-sdk-core'
 
-      client = Aws::EC2::Client.new region: ec2['placement_availability_zone'][0...-1]
-      resp = client.describe_tags(
+      ec2_client = Aws::EC2::Client.new region: ec2['placement_availability_zone'][0...-1]
+      resp = ec2_client.describe_tags(
         filters: [
           {
             name: 'resource-id',


### PR DESCRIPTION
Workaround for https://github.com/KierranM/ec2-tags-ohai-plugin/issues/3

See issue for details about why.